### PR TITLE
Fix rendering of union types in @return annotations

### DIFF
--- a/src/DocumentationHelpers.php
+++ b/src/DocumentationHelpers.php
@@ -100,7 +100,7 @@ EOT;
                 );
                 $text   = str_replace('@part ', ' * `[Part]` ', $text);
                 $text   = str_replace("@return mixed\n", '', $text);
-                $text   = preg_replace('~@return (.*?)~', ' * `return` $1', $text);
+                $text   = preg_replace('~@(return( [^\s]*)?)( (.+))?~', ' * `$1` $4', $text);
                 $text   = preg_replace("~^@(.*?)([$\s])~", ' * `$1` $2', $text);
                 $result = $title . $text;
                 return preg_replace('/\n(\s*\n){2,}/', "\n\n", $result);

--- a/src/DocumentationHelpers.php
+++ b/src/DocumentationHelpers.php
@@ -99,6 +99,7 @@ EOT;
                     $text
                 );
                 $text   = str_replace('@part ', ' * `[Part]` ', $text);
+                $text   = str_replace("@return\n", '', $text);
                 $text   = str_replace("@return mixed\n", '', $text);
                 $text   = preg_replace('~@(return( [^\s]*)?)( (.+))?~', ' * `$1` $4', $text);
                 $text   = preg_replace("~^@(.*?)([$\s])~", ' * `$1` $2', $text);


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/6104.

As mentioned in https://github.com/Codeception/Codeception/issues/6104 Jekyll renders union types (including a `|`) as html table if not inside backticks.

This PR adjusts the regex that already adjusts the rendering of `@return` annotations to also include the type hints inside the backticks. Additional comments will still be included outside of the backticks.

With this PR, the part mentioned in the linked issue (https://codeception.com/docs/modules/Symfony#grabParameter) will render as

```
 * `return mixed|null`
```

Whereas the return statement from https://codeception.com/docs/modules/Symfony#grabPageSourcewill be rendered as

```
* `return string` Current page source code.
```

Since this change also changed the rendering of those empty `@return` statements like seen at https://codeception.com/docs/modules/Yii2#seeElement which looks just misplaced and now it would be rendered as

```
* `return`
```
which I don't think is of much help, so I removed those completely from the rendered markdown.

I ran `vendor/bin/robo build:docs` in the codeception.github.com repo and checked the diff and everything looks fine to me, I also checked via jekyll using a local docker container like this

`docker run --rm --volume=$PWD:/srv/jekyll  -it -p 4000:4000 jekyll/jekyll jekyll serve`

and the rendered output looks fine to me, too.