### PR TITLE
Removing Codeception 2 and 3 note

### DIFF
--- a/src/DocumentationHelpers.php
+++ b/src/DocumentationHelpers.php
@@ -39,9 +39,6 @@ Alternatively, you can enable `$moduleName` module in suite configuration file a
 codecept init upgrade4
 ```
 
-Some modules are bundled with PHAR files.  
-Warning. Using PHAR file and composer in the same project can cause unexpected errors.  
-
 ## Description
 
 EOT;

--- a/src/DocumentationHelpers.php
+++ b/src/DocumentationHelpers.php
@@ -39,7 +39,6 @@ Alternatively, you can enable `$moduleName` module in suite configuration file a
 codecept init upgrade4
 ```
 
-This module was bundled with Codeception 2 and 3, but since version 4 it is necessary to install it separately.   
 Some modules are bundled with PHAR files.  
 Warning. Using PHAR file and composer in the same project can cause unexpected errors.  
 

--- a/src/DocumentationHelpers.php
+++ b/src/DocumentationHelpers.php
@@ -27,16 +27,8 @@ trait DocumentationHelpers
 # $moduleName
 ## Installation
 
-If you use Codeception installed using composer, install this module with the following command:
-
 ```
 composer require --dev $packageName
-```
-
-Alternatively, you can enable `$moduleName` module in suite configuration file and run
- 
-```
-codecept init upgrade4
 ```
 
 ## Description


### PR DESCRIPTION
Since Codeception 4 was released more than 4 years ago: https://github.com/Codeception/Codeception/releases/tag/4.0.0

Questions:
1. Is the alternative way `codecept init upgrade4` really useful for anybody? Or can I delete it too?
2. What does "Some modules are bundled with PHAR files." mean? When downloading the Codeception Phar executable https://codeception.com/install, some modules are included?